### PR TITLE
docs: combine IntelliJ+Windsurf config, fix VS Code logo parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ claude mcp add gitlab -- uvx mcp-gitlab
 
 ### VS Code
 
-> IntelliJ one-click install support is planned for parity with VS Code/Cursor flows.
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mcp-gitlab&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-gitlab%22%5D%2C%22env%22%3A%7B%22GITLAB_URL%22%3A%22%24%7Binput%3Agitlab-url%7D%22%2C%22GITLAB_TOKEN%22%3A%22%24%7Binput%3Agitlab-token%7D%22%7D%7D&image=https://cdn.simpleicons.org/gitlab/FC6D26&logo=https://cdn.simpleicons.org/gitlab/FC6D26) [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mcp-gitlab&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-gitlab%22%5D%2C%22env%22%3A%7B%22GITLAB_URL%22%3A%22%24%7Binput%3Agitlab-url%7D%22%2C%22GITLAB_TOKEN%22%3A%22%24%7Binput%3Agitlab-token%7D%22%7D%7D&quality=insiders&image=https://cdn.simpleicons.org/gitlab/FC6D26&logo=https://cdn.simpleicons.org/gitlab/FC6D26)
 
-[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mcp-gitlab&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-gitlab%22%5D%2C%22env%22%3A%7B%22GITLAB_URL%22%3A%22%24%7Binput%3Agitlab-url%7D%22%2C%22GITLAB_TOKEN%22%3A%22%24%7Binput%3Agitlab-token%7D%22%7D%7D&icon=https://cdn.simpleicons.org/gitlab/FC6D26) [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mcp-gitlab&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-gitlab%22%5D%2C%22env%22%3A%7B%22GITLAB_URL%22%3A%22%24%7Binput%3Agitlab-url%7D%22%2C%22GITLAB_TOKEN%22%3A%22%24%7Binput%3Agitlab-token%7D%22%7D%7D&quality=insiders&icon=https://cdn.simpleicons.org/gitlab/FC6D26)
+### Windsurf & IntelliJ
 
-### Windsurf
+**Windsurf:** Add to `~/.codeium/windsurf/mcp_config.json`
+**IntelliJ:** Add to `Settings | Tools | MCP Servers`
 
-Add to `~/.codeium/windsurf/mcp_config.json`:
-
-> The actual server config starts at `gitlab` inside `mcpServers`.
+> **Note:** The actual server config starts at `gitlab` inside the `mcpServers` object.
 
 ```json
 {
   "mcpServers": {
+    ...
     "gitlab": {
       "command": "uvx",
       "args": ["mcp-gitlab"],
@@ -46,7 +46,8 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
         "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
-    }
+    },
+    ...
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Combined IntelliJ & Windsurf config notes into a single block.
- Updated VS Code install URL to use correct `image` and `logo` parameters for the display icon.