### PR TITLE
feat: MCP tool annotations and error handling fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Thumbs.db
 .idea/
 .vscode/
 *.iml
+.claude/
+.cursorrules
+.cursor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ MCP server providing 76 tools for the GitLab REST API v4.
 - **Entry point**: `src/mcp_gitlab/__init__.py` — click CLI, loads env, runs FastMCP server
 - **Client**: `src/mcp_gitlab/client.py` — async httpx client with all GitLab API methods
 - **Tools**: `src/mcp_gitlab/servers/gitlab.py` — all FastMCP tool registrations
-- **Models**: `src/mcp_gitlab/models/` — Pydantic models for typed API responses
+- **Models**: `src/mcp_gitlab/models/` — Pydantic models for typed API responses (unused by tools)
 - **Config**: `src/mcp_gitlab/config.py` — `GitLabConfig` dataclass from env vars
 - **Exceptions**: `src/mcp_gitlab/exceptions.py` — `GitLabApiError`, `GitLabAuthError`, etc.
 
@@ -21,6 +21,39 @@ MCP server providing 76 tools for the GitLab REST API v4.
 - Client uses httpx with `PRIVATE-TOKEN` header auth
 - Project/group IDs can be numeric or URL-encoded paths
 
+## MCP Compliance Rules
+
+### Tool Annotations (MANDATORY)
+Every tool MUST have `annotations={}` with at minimum `readOnlyHint`.
+- Read tools: `annotations={"readOnlyHint": True, "idempotentHint": True}`
+- Non-destructive write tools: `annotations={"readOnlyHint": False}`
+- Destructive write tools: `annotations={"destructiveHint": True, "readOnlyHint": False}`
+- Idempotent writes (PUT/update): add `idempotentHint: True`
+
+### Tool Descriptions
+- 1-2 sentences. Front-load what it does AND what it returns.
+- Bad: "This tool gets a merge request."
+- Good: "Get merge request details. Returns title, state, branches, author, diff_refs."
+
+### Error Handling
+- Every tool MUST wrap in try/except and return `_err(e)` — never raise.
+- Error text MUST be actionable: include what went wrong and suggest a fix.
+- Never return concatenated JSON strings — always a single valid JSON object.
+- Never expose stack traces, tokens, or internal paths.
+
+### Parameter Design
+- Use `Annotated[type, Field(description="...")]` on every parameter.
+- Use `Literal[...]` for known value sets instead of plain `str`.
+- Every optional parameter must have a default.
+- Flatten — no nested dicts unless truly necessary.
+
+### Read-Only Mode
+- Every write tool MUST call `_check_write(ctx)` before any mutation.
+
+### Naming Convention
+- Pattern: `gitlab_{verb}_{resource}` (snake_case)
+- Verbs: create, get, list, search, update, delete, merge, rebase, retry, play, cancel, award, remove, share, unshare, compare, add, reply, resolve
+
 ## Tool Categories
 
 Projects (4), Approvals (10), Groups (6), Branches (3), Commits (4), Merge Requests (8), MR Notes (6), MR Discussions (4), Pipelines (5), Jobs (4), Tags (4), Releases (5), CI/CD Variables (8), Issues (5)
@@ -32,3 +65,10 @@ Projects (4), Approvals (10), Groups (6), Branches (3), Commits (4), Merge Reque
 - `GITLAB_READ_ONLY` — disable mutations
 - `GITLAB_TIMEOUT` — request timeout seconds
 - `GITLAB_SSL_VERIFY` — SSL verification toggle
+
+## Known Limitations / Future Work
+
+- 76 tools in one server file (exceeds 5-15 guideline). Consider splitting by category in a future refactor.
+- Pydantic models in `models/` are defined but unused — tools work with raw dicts. Consider removing or wiring up.
+- No tool-level tests. Client tests exist but the MCP registration layer (`servers/gitlab.py`) is untested.
+- Errors are returned as successful tool results with `{"error": ...}` (soft-error pattern). Callers must inspect JSON content.

--- a/src/mcp_gitlab/servers/gitlab.py
+++ b/src/mcp_gitlab/servers/gitlab.py
@@ -76,7 +76,10 @@ def _err(error: Exception) -> str:
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "projects", "read"})
+@mcp.tool(
+    tags={"gitlab", "projects", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_get_project(
     ctx: Context,
     project_id: Annotated[
@@ -92,7 +95,7 @@ async def gitlab_get_project(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "projects", "write"})
+@mcp.tool(tags={"gitlab", "projects", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_project(
     ctx: Context,
     name: Annotated[str, Field(description="Project name")],
@@ -125,7 +128,10 @@ async def gitlab_create_project(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "projects", "write"})
+@mcp.tool(
+    tags={"gitlab", "projects", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_delete_project(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -139,7 +145,10 @@ async def gitlab_delete_project(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "projects", "write"})
+@mcp.tool(
+    tags={"gitlab", "projects", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_update_project_merge_settings(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -184,7 +193,10 @@ async def gitlab_update_project_merge_settings(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "approvals", "read"})
+@mcp.tool(
+    tags={"gitlab", "approvals", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_get_project_approvals(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -197,7 +209,10 @@ async def gitlab_get_project_approvals(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "approvals", "write"})
+@mcp.tool(
+    tags={"gitlab", "approvals", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_update_project_approvals(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -241,7 +256,10 @@ async def gitlab_update_project_approvals(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "approvals", "read"})
+@mcp.tool(
+    tags={"gitlab", "approvals", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_project_approval_rules(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -254,7 +272,7 @@ async def gitlab_list_project_approval_rules(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "approvals", "write"})
+@mcp.tool(tags={"gitlab", "approvals", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_project_approval_rule(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -280,7 +298,10 @@ async def gitlab_create_project_approval_rule(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "approvals", "write"})
+@mcp.tool(
+    tags={"gitlab", "approvals", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_update_project_approval_rule(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -310,7 +331,10 @@ async def gitlab_update_project_approval_rule(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "approvals", "write"})
+@mcp.tool(
+    tags={"gitlab", "approvals", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_delete_project_approval_rule(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -330,7 +354,10 @@ async def gitlab_delete_project_approval_rule(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "approvals", "read"})
+@mcp.tool(
+    tags={"gitlab", "approvals", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_mr_approval_rules(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -344,7 +371,7 @@ async def gitlab_list_mr_approval_rules(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "approvals", "write"})
+@mcp.tool(tags={"gitlab", "approvals", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_mr_approval_rule(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -371,7 +398,10 @@ async def gitlab_create_mr_approval_rule(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "approvals", "write"})
+@mcp.tool(
+    tags={"gitlab", "approvals", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_update_mr_approval_rule(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -400,7 +430,10 @@ async def gitlab_update_mr_approval_rule(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "approvals", "write"})
+@mcp.tool(
+    tags={"gitlab", "approvals", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_delete_mr_approval_rule(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -421,7 +454,10 @@ async def gitlab_delete_mr_approval_rule(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "groups", "read"})
+@mcp.tool(
+    tags={"gitlab", "groups", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_groups(
     ctx: Context,
     search: Annotated[str | None, Field(description="Search by name")] = None,
@@ -440,7 +476,10 @@ async def gitlab_list_groups(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "groups", "read"})
+@mcp.tool(
+    tags={"gitlab", "groups", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_get_group(
     ctx: Context,
     group_id: Annotated[str, Field(description="Group ID or URL-encoded path")],
@@ -453,7 +492,7 @@ async def gitlab_get_group(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "groups", "write"})
+@mcp.tool(tags={"gitlab", "groups", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_share_project_with_group(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -476,7 +515,10 @@ async def gitlab_share_project_with_group(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "groups", "write"})
+@mcp.tool(
+    tags={"gitlab", "groups", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_unshare_project_with_group(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -491,7 +533,7 @@ async def gitlab_unshare_project_with_group(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "groups", "write"})
+@mcp.tool(tags={"gitlab", "groups", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_share_group_with_group(
     ctx: Context,
     target_group_id: Annotated[str, Field(description="Target group ID or path")],
@@ -512,7 +554,10 @@ async def gitlab_share_group_with_group(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "groups", "write"})
+@mcp.tool(
+    tags={"gitlab", "groups", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_unshare_group_with_group(
     ctx: Context,
     target_group_id: Annotated[str, Field(description="Target group ID or path")],
@@ -532,7 +577,10 @@ async def gitlab_unshare_group_with_group(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "branches", "read"})
+@mcp.tool(
+    tags={"gitlab", "branches", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_branches(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -552,7 +600,7 @@ async def gitlab_list_branches(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "branches", "write"})
+@mcp.tool(tags={"gitlab", "branches", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_branch(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -568,7 +616,10 @@ async def gitlab_create_branch(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "branches", "write"})
+@mcp.tool(
+    tags={"gitlab", "branches", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_delete_branch(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -588,7 +639,10 @@ async def gitlab_delete_branch(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "commits", "read"})
+@mcp.tool(
+    tags={"gitlab", "commits", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_commits(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -617,7 +671,10 @@ async def gitlab_list_commits(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "commits", "read"})
+@mcp.tool(
+    tags={"gitlab", "commits", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_get_commit(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -636,7 +693,7 @@ async def gitlab_get_commit(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "commits", "write"})
+@mcp.tool(tags={"gitlab", "commits", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_commit(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -669,7 +726,10 @@ async def gitlab_create_commit(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "commits", "read"})
+@mcp.tool(
+    tags={"gitlab", "commits", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_compare(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -689,7 +749,10 @@ async def gitlab_compare(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "merge_requests", "read"})
+@mcp.tool(
+    tags={"gitlab", "merge_requests", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_mrs(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -724,13 +787,19 @@ async def gitlab_list_mrs(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "merge_requests", "read"})
+@mcp.tool(
+    tags={"gitlab", "merge_requests", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_get_mr(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
     mr_iid: Annotated[int, Field(description="Merge request IID")],
 ) -> str:
-    """Get details of a merge request."""
+    """Get merge request details.
+
+    Returns title, state, source/target branches, author, diff_refs, and merge status.
+    """
     try:
         data = await _get_client(ctx).get_merge_request(project_id, mr_iid)
         return _ok(data)
@@ -738,7 +807,7 @@ async def gitlab_get_mr(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "merge_requests", "write"})
+@mcp.tool(tags={"gitlab", "merge_requests", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_mr(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -777,7 +846,10 @@ async def gitlab_create_mr(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "merge_requests", "write"})
+@mcp.tool(
+    tags={"gitlab", "merge_requests", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_update_mr(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -819,7 +891,7 @@ async def gitlab_update_mr(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "merge_requests", "write"})
+@mcp.tool(tags={"gitlab", "merge_requests", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_merge_mr(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -858,7 +930,7 @@ async def gitlab_merge_mr(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "merge_requests", "write"})
+@mcp.tool(tags={"gitlab", "merge_requests", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_merge_mr_sequence(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -901,12 +973,16 @@ async def gitlab_merge_mr_sequence(
 
         return _ok({"status": "all_merged", "merged": merged})
     except Exception as e:
-        err = _err(e)
-        merged_info = json.dumps({"merged_so_far": merged})
-        return f"{err}\n{merged_info}"
+        detail: dict[str, Any] = {"error": str(e), "merged_so_far": merged}
+        from ..exceptions import GitLabApiError
+
+        if isinstance(e, GitLabApiError):
+            detail["status_code"] = e.status_code
+            detail["body"] = e.body
+        return json.dumps(detail, indent=2, ensure_ascii=False)
 
 
-@mcp.tool(tags={"gitlab", "merge_requests", "write"})
+@mcp.tool(tags={"gitlab", "merge_requests", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_rebase_mr(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -922,13 +998,16 @@ async def gitlab_rebase_mr(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "merge_requests", "read"})
+@mcp.tool(
+    tags={"gitlab", "merge_requests", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_mr_changes(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
     mr_iid: Annotated[int, Field(description="Merge request IID")],
 ) -> str:
-    """Get the file changes (diff) of a merge request."""
+    """Get file changes of a merge request. Returns list of diffs with old/new paths and content."""
     try:
         data = await _get_client(ctx).get_merge_request_changes(project_id, mr_iid)
         return _ok(data)
@@ -941,7 +1020,10 @@ async def gitlab_mr_changes(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "notes", "read"})
+@mcp.tool(
+    tags={"gitlab", "notes", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_mr_notes(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -958,7 +1040,7 @@ async def gitlab_list_mr_notes(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "notes", "write"})
+@mcp.tool(tags={"gitlab", "notes", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_add_mr_note(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -977,7 +1059,10 @@ async def gitlab_add_mr_note(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "notes", "write"})
+@mcp.tool(
+    tags={"gitlab", "notes", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_delete_mr_note(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -993,7 +1078,10 @@ async def gitlab_delete_mr_note(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "notes", "write"})
+@mcp.tool(
+    tags={"gitlab", "notes", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_update_mr_note(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1010,7 +1098,7 @@ async def gitlab_update_mr_note(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "notes", "write"})
+@mcp.tool(tags={"gitlab", "notes", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_award_emoji(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1027,7 +1115,10 @@ async def gitlab_award_emoji(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "notes", "write"})
+@mcp.tool(
+    tags={"gitlab", "notes", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_remove_emoji(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1049,13 +1140,19 @@ async def gitlab_remove_emoji(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "discussions", "read"})
+@mcp.tool(
+    tags={"gitlab", "discussions", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_mr_discussions(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
     mr_iid: Annotated[int, Field(description="Merge request IID")],
 ) -> str:
-    """List discussions on a merge request (excludes system notes)."""
+    """List discussions on a merge request.
+
+    Returns discussion threads with notes, excluding system notes.
+    """
     try:
         data = await _get_client(ctx).list_mr_discussions(project_id, mr_iid)
         # Filter out system-only discussions
@@ -1069,7 +1166,7 @@ async def gitlab_list_mr_discussions(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "discussions", "write"})
+@mcp.tool(tags={"gitlab", "discussions", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_mr_discussion(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1130,7 +1227,7 @@ async def gitlab_create_mr_discussion(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "discussions", "write"})
+@mcp.tool(tags={"gitlab", "discussions", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_reply_to_discussion(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1147,7 +1244,10 @@ async def gitlab_reply_to_discussion(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "discussions", "write"})
+@mcp.tool(
+    tags={"gitlab", "discussions", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_resolve_discussion(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1171,7 +1271,10 @@ async def gitlab_resolve_discussion(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "pipelines", "read"})
+@mcp.tool(
+    tags={"gitlab", "pipelines", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_pipelines(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1185,7 +1288,7 @@ async def gitlab_list_pipelines(
     ] = None,
     per_page: Annotated[int | None, Field(description="Results per page")] = None,
 ) -> str:
-    """List pipelines for a project."""
+    """List pipelines for a project. Returns id, status, ref, source, created_at."""
     try:
         params: dict[str, Any] = {}
         if ref:
@@ -1202,7 +1305,10 @@ async def gitlab_list_pipelines(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "pipelines", "read"})
+@mcp.tool(
+    tags={"gitlab", "pipelines", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_get_pipeline(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1221,7 +1327,7 @@ async def gitlab_get_pipeline(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "pipelines", "write"})
+@mcp.tool(tags={"gitlab", "pipelines", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_pipeline(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1240,7 +1346,7 @@ async def gitlab_create_pipeline(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "pipelines", "write"})
+@mcp.tool(tags={"gitlab", "pipelines", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_retry_pipeline(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1255,7 +1361,10 @@ async def gitlab_retry_pipeline(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "pipelines", "write"})
+@mcp.tool(
+    tags={"gitlab", "pipelines", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_cancel_pipeline(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1275,7 +1384,7 @@ async def gitlab_cancel_pipeline(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "jobs", "write"})
+@mcp.tool(tags={"gitlab", "jobs", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_retry_job(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1290,7 +1399,7 @@ async def gitlab_retry_job(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "jobs", "write"})
+@mcp.tool(tags={"gitlab", "jobs", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_play_job(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1309,7 +1418,10 @@ async def gitlab_play_job(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "jobs", "write"})
+@mcp.tool(
+    tags={"gitlab", "jobs", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_cancel_job(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1324,7 +1436,10 @@ async def gitlab_cancel_job(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "jobs", "read"})
+@mcp.tool(
+    tags={"gitlab", "jobs", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_get_job_log(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1353,7 +1468,10 @@ async def gitlab_get_job_log(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "tags", "read"})
+@mcp.tool(
+    tags={"gitlab", "tags", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_tags(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1379,7 +1497,10 @@ async def gitlab_list_tags(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "tags", "read"})
+@mcp.tool(
+    tags={"gitlab", "tags", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_get_tag(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1393,7 +1514,7 @@ async def gitlab_get_tag(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "tags", "write"})
+@mcp.tool(tags={"gitlab", "tags", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_tag(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1413,7 +1534,10 @@ async def gitlab_create_tag(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "tags", "write"})
+@mcp.tool(
+    tags={"gitlab", "tags", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_delete_tag(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1433,7 +1557,10 @@ async def gitlab_delete_tag(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "releases", "read"})
+@mcp.tool(
+    tags={"gitlab", "releases", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_releases(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1450,7 +1577,10 @@ async def gitlab_list_releases(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "releases", "read"})
+@mcp.tool(
+    tags={"gitlab", "releases", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_get_release(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1464,7 +1594,7 @@ async def gitlab_get_release(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "releases", "write"})
+@mcp.tool(tags={"gitlab", "releases", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_release(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1498,7 +1628,10 @@ async def gitlab_create_release(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "releases", "write"})
+@mcp.tool(
+    tags={"gitlab", "releases", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_update_release(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1523,7 +1656,10 @@ async def gitlab_update_release(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "releases", "write"})
+@mcp.tool(
+    tags={"gitlab", "releases", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_delete_release(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1543,7 +1679,10 @@ async def gitlab_delete_release(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "variables", "read"})
+@mcp.tool(
+    tags={"gitlab", "variables", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_variables(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1559,7 +1698,7 @@ async def gitlab_list_variables(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "variables", "write"})
+@mcp.tool(tags={"gitlab", "variables", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_variable(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1598,7 +1737,10 @@ async def gitlab_create_variable(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "variables", "write"})
+@mcp.tool(
+    tags={"gitlab", "variables", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_update_variable(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1633,7 +1775,10 @@ async def gitlab_update_variable(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "variables", "write"})
+@mcp.tool(
+    tags={"gitlab", "variables", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_delete_variable(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1654,7 +1799,10 @@ async def gitlab_delete_variable(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "variables", "read"})
+@mcp.tool(
+    tags={"gitlab", "variables", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_group_variables(
     ctx: Context,
     group_id: Annotated[str, Field(description="Group ID or path")],
@@ -1670,7 +1818,7 @@ async def gitlab_list_group_variables(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "variables", "write"})
+@mcp.tool(tags={"gitlab", "variables", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_group_variable(
     ctx: Context,
     group_id: Annotated[str, Field(description="Group ID or path")],
@@ -1705,7 +1853,10 @@ async def gitlab_create_group_variable(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "variables", "write"})
+@mcp.tool(
+    tags={"gitlab", "variables", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_update_group_variable(
     ctx: Context,
     group_id: Annotated[str, Field(description="Group ID or path")],
@@ -1737,7 +1888,10 @@ async def gitlab_update_group_variable(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "variables", "write"})
+@mcp.tool(
+    tags={"gitlab", "variables", "write"},
+    annotations={"destructiveHint": True, "readOnlyHint": False},
+)
 async def gitlab_delete_group_variable(
     ctx: Context,
     group_id: Annotated[str, Field(description="Group ID or path")],
@@ -1757,7 +1911,10 @@ async def gitlab_delete_group_variable(
 # ════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(tags={"gitlab", "issues", "read"})
+@mcp.tool(
+    tags={"gitlab", "issues", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_list_issues(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1786,7 +1943,10 @@ async def gitlab_list_issues(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "issues", "read"})
+@mcp.tool(
+    tags={"gitlab", "issues", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def gitlab_get_issue(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1800,7 +1960,7 @@ async def gitlab_get_issue(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "issues", "write"})
+@mcp.tool(tags={"gitlab", "issues", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_create_issue(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1834,7 +1994,10 @@ async def gitlab_create_issue(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "issues", "write"})
+@mcp.tool(
+    tags={"gitlab", "issues", "write"},
+    annotations={"readOnlyHint": False, "idempotentHint": True},
+)
 async def gitlab_update_issue(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],
@@ -1868,7 +2031,7 @@ async def gitlab_update_issue(
         return _err(e)
 
 
-@mcp.tool(tags={"gitlab", "issues", "write"})
+@mcp.tool(tags={"gitlab", "issues", "write"}, annotations={"readOnlyHint": False})
 async def gitlab_add_issue_comment(
     ctx: Context,
     project_id: Annotated[str, Field(description="Project ID or path")],

--- a/uv.lock
+++ b/uv.lock
@@ -816,7 +816,7 @@ wheels = [
 
 [[package]]
 name = "mcp-gitlab"
-version = "0.2.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Add `readOnlyHint`, `destructiveHint`, `idempotentHint` annotations to all 76 tools
- Fix `gitlab_merge_mr_sequence`: return single valid JSON object on error (was concatenating two JSON strings), include `body` field for parity with `_err()`
- Improve descriptions on 4 high-frequency tools (`get_mr`, `mr_changes`, `list_mr_discussions`, `list_pipelines`)
- Update AGENTS.md with MCP compliance rules and known limitations
- Add `.claude/`, `.cursor/`, `.cursorrules` to `.gitignore`

## Annotation breakdown
| Category | Count | Annotation |
|----------|-------|------------|
| Read tools | 32 | `readOnlyHint: True, idempotentHint: True` |
| Non-destructive writes | 18 | `readOnlyHint: False` |
| Idempotent writes (update/PUT) | 12 | `readOnlyHint: False, idempotentHint: True` |
| Destructive writes (delete) | 14 | `destructiveHint: True, readOnlyHint: False` |

## Test plan
- [x] `uv run pytest` — 25 passed
- [x] `uv run ruff check .` — all checks passed
- [x] Reference scan clean (no proprietary data)