### PR TITLE
feat: add MCP prompts for multi-tool workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ MCP server providing 76 tools for the GitLab REST API v4.
 - **Client**: `src/mcp_gitlab/client.py` — async httpx client with all GitLab API methods
 - **Tools**: `src/mcp_gitlab/servers/gitlab.py` — all FastMCP tool registrations
 - **Resources**: `src/mcp_gitlab/servers/resources.py` — 6 MCP resources (workflow guides)
+- **Prompts**: `src/mcp_gitlab/servers/prompts.py` — 5 MCP prompts (multi-tool workflows)
 - **Config**: `src/mcp_gitlab/config.py` — `GitLabConfig` dataclass from env vars
 - **Exceptions**: `src/mcp_gitlab/exceptions.py` — `GitLabApiError`, `GitLabAuthError`, etc.
 - **Tests**: `tests/unit/test_tools.py` — 120+ tool-level tests via FastMCP test client
@@ -93,6 +94,16 @@ gh workflow run release.yml -f bump=minor -f dry_run=true
 - Never create tags manually — the workflow creates them
 - Commit messages must follow conventional commits (`feat:`, `fix:`, `docs:`, etc.) for changelog generation
 - The release commit is authored by `github-actions[bot]` with message `chore(release): X.Y.Z`
+
+## Prompts
+
+Prompts follow the resources pattern: prompt content lives as `.md` files in `src/mcp_gitlab/resources/prompts/`, loaded by `servers/prompts.py` via `_load_prompt()`, registered with `@mcp.prompt()`. Each prompt returns `list[Message]` with a user message (workflow template) and an assistant message (acknowledgment).
+
+- `review_mr` — MR review workflow (tags: gitlab, review)
+- `diagnose_pipeline` — CI debug workflow (tags: gitlab, ci)
+- `prepare_release` — Release preparation (tags: gitlab, release)
+- `setup_branch_protection` — Branch protection setup (tags: gitlab, settings)
+- `triage_issues` — Issue triage workflow (tags: gitlab, issues)
 
 ## Known Limitations / Future Work
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/vish288/mcp-gitlab/actions/workflows/tests.yml/badge.svg)](https://github.com/vish288/mcp-gitlab/actions/workflows/tests.yml)
 
-**mcp-gitlab** is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for the GitLab REST API that provides **76 tools** for AI assistants to manage projects, merge requests, pipelines, CI/CD variables, approvals, issues, code reviews, and more. Works with Claude Desktop, Claude Code, Cursor, Windsurf, VS Code Copilot, and any MCP-compatible client.
+**mcp-gitlab** is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for the GitLab REST API that provides **76 tools**, **6 resources**, and **5 prompts** for AI assistants to manage projects, merge requests, pipelines, CI/CD variables, approvals, issues, code reviews, and more. Works with Claude Desktop, Claude Code, Cursor, Windsurf, VS Code Copilot, and any MCP-compatible client.
 
 Built with [FastMCP](https://github.com/jlowin/fastmcp), [httpx](https://www.python-httpx.org/), and [Pydantic](https://docs.pydantic.dev/).
 
@@ -259,6 +259,18 @@ The server exposes curated workflow guides as [MCP resources](https://modelconte
 | `resource://rules/conventional-commits` | Conventional Commits Spec |
 | `resource://guides/code-review` | Code Review Standards |
 | `resource://guides/codeowners` | GitLab CODEOWNERS Reference |
+
+## Prompts (5)
+
+The server provides [MCP prompts](https://modelcontextprotocol.io/docs/concepts/prompts) — reusable multi-tool workflow templates that clients can surface as slash commands.
+
+| Prompt | Parameters | Workflow |
+|--------|-----------|----------|
+| `review_mr` | `project_id`, `mr_iid` | Fetch MR → check pipeline → review changes → write discussion notes |
+| `diagnose_pipeline` | `project_id`, `pipeline_id` | Fetch pipeline → identify failed jobs → get logs → suggest fix |
+| `prepare_release` | `project_id`, `tag_name`, `ref` | Compare commits since last tag → draft changelog → create tag + release |
+| `setup_branch_protection` | `project_id` | Review settings → configure merge method → set approval rules |
+| `triage_issues` | `project_id`, `label` | List open issues → categorize → prioritize → identify duplicates |
 
 ## Usage Examples
 

--- a/src/mcp_gitlab/__init__.py
+++ b/src/mcp_gitlab/__init__.py
@@ -37,7 +37,7 @@ def main(
     if read_only:
         os.environ["GITLAB_READ_ONLY"] = "true"
 
-    from .servers import resources  # noqa: F401 — registers @mcp.resource decorators
+    from .servers import prompts, resources  # noqa: F401 — registers decorators
     from .servers.gitlab import mcp
 
     run_kwargs: dict = {"transport": transport}

--- a/src/mcp_gitlab/resources/prompts/diagnose-pipeline.md
+++ b/src/mcp_gitlab/resources/prompts/diagnose-pipeline.md
@@ -1,0 +1,16 @@
+# Diagnose pipeline {pipeline_id} in project {project_id}
+
+## Steps
+
+1. **Fetch pipeline details** — use `gitlab_get_pipeline` with project_id="{project_id}" and pipeline_id="{pipeline_id}". Note the status, ref, and created timestamp.
+2. **Identify failed jobs** — from the pipeline response, find jobs with status "failed". List each failed job with its name, stage, and runner.
+3. **Get job logs** — for each failed job, use `gitlab_get_job_log` to retrieve the trace output. Focus on the last 100 lines where errors typically appear.
+4. **Analyze errors** — for each failed job log, identify:
+   - The root error message (compilation error, test failure, timeout, OOM, dependency issue)
+   - Whether the failure is flaky (transient network issue, timing) or deterministic (code bug)
+   - Any missing environment variables or secrets
+5. **Suggest resolution** — for each failure:
+   - If flaky: suggest retry via `gitlab_retry_job`
+   - If deterministic: describe what code change or config fix is needed
+   - If infra-related: flag for manual investigation
+6. **Summary** — provide a table of failed jobs with diagnosis and recommended action.

--- a/src/mcp_gitlab/resources/prompts/prepare-release.md
+++ b/src/mcp_gitlab/resources/prompts/prepare-release.md
@@ -1,0 +1,15 @@
+# Prepare release {tag_name} from {ref} in project {project_id}
+
+## Steps
+
+1. **List existing tags** — use `gitlab_list_tags` with project_id="{project_id}" to find the most recent tag. This is the baseline for the changelog.
+2. **Compare commits** — use `gitlab_compare` with project_id="{project_id}", from the previous tag to "{ref}". This gives all commits that will be in this release.
+3. **Build changelog** — from the commit list, group by conventional commit type:
+   - **Features** (`feat:`): new functionality
+   - **Fixes** (`fix:`): bug corrections
+   - **Breaking Changes** (`BREAKING CHANGE:` or `!:`): API/behavior changes
+   - **Other**: refactor, docs, chore, ci, test, perf
+4. **Draft release notes** — format as markdown with sections for each group. Include commit hash references and author attribution.
+5. **Create tag** — use `gitlab_create_tag` with project_id="{project_id}", tag_name="{tag_name}", ref="{ref}", and the release notes as the message.
+6. **Create release** — use `gitlab_create_release` with project_id="{project_id}", tag_name="{tag_name}", and the formatted changelog as the description.
+7. **Verify** — confirm the tag and release were created. Report any issues.

--- a/src/mcp_gitlab/resources/prompts/review-mr.md
+++ b/src/mcp_gitlab/resources/prompts/review-mr.md
@@ -1,0 +1,29 @@
+# Review MR !{mr_iid} in project {project_id}
+
+## Steps
+
+1. **Fetch MR details** — use `gitlab_get_mr` with project_id="{project_id}" and mr_iid="{mr_iid}". Note the author, source/target branches, description, and labels.
+2. **Check pipeline status** — use `gitlab_get_pipeline` with the pipeline ID from step 1. If CI has not passed, flag it before proceeding.
+3. **Get the diff** — use `gitlab_mr_changes` to retrieve all changed files.
+4. **Review each changed file** — evaluate:
+   - Correctness and logic errors
+   - Test coverage for new/changed code paths
+   - Security implications (injection, auth, secrets)
+   - Performance (N+1 queries, unnecessary allocations)
+   - Naming clarity and code style consistency
+5. **Write inline comments** — use `gitlab_create_mr_discussion` for each finding, anchored to the relevant file and line. Use Conventional Comments labels (suggestion, issue, nitpick, praise).
+6. **Summarize** — post an overall MR note via `gitlab_add_mr_note` with:
+   - What the MR does well
+   - Blocking issues (if any)
+   - Non-blocking suggestions
+7. **Verdict** — approve if no blocking issues, otherwise request changes.
+
+## Review Priority Order
+
+1. Design — is the overall approach sound?
+2. Functionality — does it do what the description says?
+3. Complexity — could a future reader understand it quickly?
+4. Tests — are they correct, meaningful, and covering edge cases?
+5. Naming — are variables, functions, and files clearly named?
+6. Comments — do they explain "why", not "what"?
+7. Style — consistent with the rest of the codebase?

--- a/src/mcp_gitlab/resources/prompts/setup-branch-protection.md
+++ b/src/mcp_gitlab/resources/prompts/setup-branch-protection.md
@@ -1,0 +1,20 @@
+# Set up branch protection for project {project_id}
+
+## Steps
+
+1. **Review current settings** — use `gitlab_get_project` with project_id="{project_id}" to check the current merge method, approval settings, and default branch.
+2. **Check existing approvals** — use `gitlab_get_project_approvals` to see current approval rules and required approval count.
+3. **Configure merge method** — use `gitlab_update_project_merge_settings` to set:
+   - Merge method (merge commit, rebase, fast-forward)
+   - Whether to delete source branch after merge
+   - Whether to squash commits
+   - Pipeline success requirement
+4. **Set approval requirements** — use `gitlab_update_project_approvals` to configure:
+   - Required number of approvals
+   - Whether authors can approve their own MRs
+   - Whether to reset approvals on new pushes
+5. **Create approval rules** — use `gitlab_create_project_approval_rule` to define who must approve:
+   - Code owners rule
+   - Team-specific rules (e.g., security team for sensitive paths)
+6. **Verify** — re-fetch project settings and approval rules to confirm everything is applied correctly.
+7. **Summary** — report what was configured and any settings that require manual adjustment in the GitLab UI.

--- a/src/mcp_gitlab/resources/prompts/triage-issues.md
+++ b/src/mcp_gitlab/resources/prompts/triage-issues.md
@@ -1,0 +1,29 @@
+# Triage issues in project {project_id}
+
+## Parameters
+- **Label filter**: {label}
+
+## Steps
+
+1. **List open issues** — use `gitlab_list_issues` with project_id="{project_id}", state="opened", and labels="{label}" (if provided). Retrieve up to 100 issues.
+2. **Categorize** — group issues by:
+   - **Bug reports**: issues with "bug" label or bug-related keywords
+   - **Feature requests**: issues with "feature" or "enhancement" labels
+   - **Questions/Support**: issues asking for help or clarification
+   - **Stale**: issues with no activity in the last 30 days
+3. **Assess priority** — for each issue, consider:
+   - Number of upvotes/reactions
+   - Whether it has a milestone assigned
+   - Age (older unaddressed issues may need attention)
+   - Whether it blocks other issues
+4. **Identify duplicates** — look for issues with similar titles or descriptions. Suggest closing duplicates with a reference to the original.
+5. **Suggest labels** — for unlabeled issues, recommend appropriate labels based on content analysis.
+6. **Apply updates** — use `gitlab_update_issue` to:
+   - Add missing labels
+   - Set priority labels where appropriate
+   - Close confirmed duplicates with a comment
+7. **Summary** — provide a triage report:
+   - Total open issues by category
+   - Top priority items needing immediate attention
+   - Stale issues recommended for closure
+   - Duplicates identified

--- a/src/mcp_gitlab/servers/prompts.py
+++ b/src/mcp_gitlab/servers/prompts.py
@@ -1,0 +1,113 @@
+"""MCP prompts — multi-tool workflow templates for GitLab operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastmcp.prompts.prompt import Message
+
+from .gitlab import mcp
+
+_PROMPTS_DIR = Path(__file__).resolve().parent.parent / "resources" / "prompts"
+
+
+def _load_prompt(filename: str) -> str:
+    """Load a prompt markdown file from the prompts directory."""
+    if "/" in filename or "\\" in filename or ".." in filename:
+        msg = f"Invalid prompt filename: {filename}"
+        raise ValueError(msg)
+    path = _PROMPTS_DIR / filename
+    if not path.resolve().is_relative_to(_PROMPTS_DIR.resolve()):
+        msg = f"Invalid prompt filename: {filename}"
+        raise ValueError(msg)
+    return path.read_text(encoding="utf-8")
+
+
+@mcp.prompt(tags={"gitlab", "review"})
+def review_mr(project_id: str, mr_iid: str) -> list[Message]:
+    """Review a GitLab merge request — fetch details, check pipeline, review
+    changes, and write discussion comments."""
+    text = _load_prompt("review-mr.md").format(project_id=project_id, mr_iid=mr_iid)
+    return [
+        Message(role="user", content=text),
+        Message(
+            role="assistant",
+            content=(
+                f"I'll review MR !{mr_iid} in project {project_id}. "
+                "Let me start by fetching the MR details and pipeline status."
+            ),
+        ),
+    ]
+
+
+@mcp.prompt(tags={"gitlab", "ci"})
+def diagnose_pipeline(project_id: str, pipeline_id: str) -> list[Message]:
+    """Diagnose a failed CI/CD pipeline — identify failed jobs, get logs,
+    analyze errors, and suggest fixes."""
+    text = _load_prompt("diagnose-pipeline.md").format(
+        project_id=project_id, pipeline_id=pipeline_id
+    )
+    return [
+        Message(role="user", content=text),
+        Message(
+            role="assistant",
+            content=(
+                f"I'll diagnose pipeline {pipeline_id} in project {project_id}. "
+                "Let me fetch the pipeline details and check for failed jobs."
+            ),
+        ),
+    ]
+
+
+@mcp.prompt(tags={"gitlab", "release"})
+def prepare_release(project_id: str, tag_name: str, ref: str = "main") -> list[Message]:
+    """Prepare a release — compare commits since last tag, draft changelog,
+    create tag and release."""
+    text = _load_prompt("prepare-release.md").format(
+        project_id=project_id, tag_name=tag_name, ref=ref
+    )
+    return [
+        Message(role="user", content=text),
+        Message(
+            role="assistant",
+            content=(
+                f"I'll prepare release {tag_name} from {ref} in project {project_id}. "
+                "Let me find the previous tag and compare commits."
+            ),
+        ),
+    ]
+
+
+@mcp.prompt(tags={"gitlab", "settings"})
+def setup_branch_protection(project_id: str) -> list[Message]:
+    """Set up branch protection — review settings, configure merge method,
+    and create approval rules."""
+    text = _load_prompt("setup-branch-protection.md").format(project_id=project_id)
+    return [
+        Message(role="user", content=text),
+        Message(
+            role="assistant",
+            content=(
+                f"I'll help set up branch protection for project {project_id}. "
+                "Let me review the current project settings and approval configuration."
+            ),
+        ),
+    ]
+
+
+@mcp.prompt(tags={"gitlab", "issues"})
+def triage_issues(project_id: str, label: str = "") -> list[Message]:
+    """Triage open issues — categorize, prioritize, identify duplicates,
+    and suggest labels."""
+    text = _load_prompt("triage-issues.md").format(project_id=project_id, label=label)
+    return [
+        Message(role="user", content=text),
+        Message(
+            role="assistant",
+            content=(
+                f"I'll triage open issues in project {project_id}"
+                + (f' filtered by label "{label}"' if label else "")
+                + ". Let me start by listing the open issues."
+            ),
+        ),
+    ]

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,0 +1,161 @@
+"""Tests for MCP prompt registration and content."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_gitlab.servers.prompts import (
+    _PROMPTS_DIR,
+    _load_prompt,
+    diagnose_pipeline,
+    prepare_release,
+    review_mr,
+    setup_branch_protection,
+    triage_issues,
+)
+
+EXPECTED_PROMPTS = {
+    "review_mr": {
+        "fn": review_mr,
+        "file": "review-mr.md",
+        "args": {"project_id": "123", "mr_iid": "42"},
+    },
+    "diagnose_pipeline": {
+        "fn": diagnose_pipeline,
+        "file": "diagnose-pipeline.md",
+        "args": {"project_id": "123", "pipeline_id": "999"},
+    },
+    "prepare_release": {
+        "fn": prepare_release,
+        "file": "prepare-release.md",
+        "args": {"project_id": "123", "tag_name": "v1.0.0", "ref": "main"},
+    },
+    "setup_branch_protection": {
+        "fn": setup_branch_protection,
+        "file": "setup-branch-protection.md",
+        "args": {"project_id": "123"},
+    },
+    "triage_issues": {
+        "fn": triage_issues,
+        "file": "triage-issues.md",
+        "args": {"project_id": "123", "label": "bug"},
+    },
+}
+
+PROMPT_FILES = [info["file"] for info in EXPECTED_PROMPTS.values()]
+
+
+class TestPromptFiles:
+    """Verify prompt .md files exist and are valid."""
+
+    def test_prompts_dir_exists(self) -> None:
+        assert _PROMPTS_DIR.is_dir(), f"Prompts directory missing: {_PROMPTS_DIR}"
+
+    def test_all_files_exist(self) -> None:
+        for filename in PROMPT_FILES:
+            path = _PROMPTS_DIR / filename
+            assert path.is_file(), f"Missing prompt file: {path}"
+
+    def test_load_returns_content(self) -> None:
+        for filename in PROMPT_FILES:
+            content = _load_prompt(filename)
+            assert len(content) > 100, f"{filename} too short ({len(content)} chars)"
+
+    def test_content_starts_with_heading(self) -> None:
+        for filename in PROMPT_FILES:
+            content = _load_prompt(filename)
+            assert content.lstrip().startswith("#"), (
+                f"{filename} should start with markdown heading"
+            )
+
+    def test_no_python_escape_artifacts(self) -> None:
+        """Ensure .md files don't contain Python string artifacts."""
+        for filename in PROMPT_FILES:
+            content = _load_prompt(filename)
+            assert '"""' not in content, f"{filename} contains triple-quote artifact"
+
+
+class TestLoadPromptSecurity:
+    """Verify _load_prompt() rejects path traversal attempts."""
+
+    def test_rejects_directory_traversal(self) -> None:
+        with pytest.raises(ValueError, match="Invalid prompt filename"):
+            _load_prompt("../../../etc/passwd")
+
+    def test_rejects_forward_slash(self) -> None:
+        with pytest.raises(ValueError, match="Invalid prompt filename"):
+            _load_prompt("subdir/file.md")
+
+    def test_rejects_backslash(self) -> None:
+        with pytest.raises(ValueError, match="Invalid prompt filename"):
+            _load_prompt("subdir\\file.md")
+
+    def test_rejects_dotdot_only(self) -> None:
+        with pytest.raises(ValueError, match="Invalid prompt filename"):
+            _load_prompt("..")
+
+
+class TestPromptRegistration:
+    """Verify prompts are registered and return valid messages."""
+
+    def test_prompt_count(self) -> None:
+        assert len(EXPECTED_PROMPTS) == 5
+
+    def test_each_prompt_returns_messages(self) -> None:
+        for name, info in EXPECTED_PROMPTS.items():
+            result = info["fn"](**info["args"])
+            assert isinstance(result, list), f"{name} should return a list"
+            assert len(result) == 2, f"{name} should return 2 messages"
+
+    def test_first_message_is_user_role(self) -> None:
+        for name, info in EXPECTED_PROMPTS.items():
+            result = info["fn"](**info["args"])
+            assert result[0].role == "user", f"{name} first message should be user role"
+
+    def test_second_message_is_assistant_role(self) -> None:
+        for name, info in EXPECTED_PROMPTS.items():
+            result = info["fn"](**info["args"])
+            assert result[1].role == "assistant", f"{name} second message should be assistant role"
+
+    def test_args_are_interpolated(self) -> None:
+        result = review_mr(project_id="456", mr_iid="78")
+        assert "456" in result[0].content.text
+        assert "78" in result[0].content.text
+        assert "78" in result[1].content.text
+
+    def test_prepare_release_default_ref(self) -> None:
+        result = prepare_release(project_id="123", tag_name="v2.0.0")
+        assert "main" in result[0].content.text
+
+    def test_triage_issues_empty_label(self) -> None:
+        result = triage_issues(project_id="123", label="")
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_prompt_functions_have_metadata(self) -> None:
+        for name, info in EXPECTED_PROMPTS.items():
+            fn = info["fn"]
+            assert hasattr(fn, "__fastmcp__"), f"{name} function missing __fastmcp__ metadata"
+
+
+class TestPromptRendering:
+    """Verify prompts render via FastMCP."""
+
+    @pytest.mark.asyncio
+    async def test_list_prompts(self) -> None:
+        from mcp_gitlab.servers.gitlab import mcp
+
+        prompts = await mcp.list_prompts()
+        prompt_names = {p.name for p in prompts}
+        for name in EXPECTED_PROMPTS:
+            assert name in prompt_names, f"Prompt {name} not listed"
+
+    @pytest.mark.asyncio
+    async def test_render_review_mr(self) -> None:
+        from mcp_gitlab.servers.gitlab import mcp
+
+        result = await mcp.render_prompt(
+            "review_mr", arguments={"project_id": "123", "mr_iid": "42"}
+        )
+        assert len(result.messages) == 2
+        assert "42" in result.messages[0].content.text


### PR DESCRIPTION
## Summary

- Add 5 MCP prompts: `review_mr`, `diagnose_pipeline`, `prepare_release`, `setup_branch_protection`, `triage_issues`
- Prompt markdown files in `resources/prompts/`, loaded by `servers/prompts.py` via same pattern as resources
- 18 tests covering file loading, path traversal security, registration, and FastMCP rendering

## Test plan

- [x] `uv run pytest tests/unit/test_prompts.py -v` — 18 passed
- [x] `uv run pytest tests/` — 176 passed (no regression)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] `list_prompts()` returns 5 prompts in a live client

Closes #22