### PR TITLE
feat: support additional token env var aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,14 @@ uv pip install mcp-gitlab
 
 ### Supported Token Types
 
-`GITLAB_TOKEN` (or `GITLAB_PAT`) accepts any of these:
+The server checks these environment variables in order — first match wins:
+
+1. `GITLAB_TOKEN`
+2. `GITLAB_PAT`
+3. `GITLAB_PERSONAL_ACCESS_TOKEN`
+4. `GITLAB_API_TOKEN`
+
+These accept any of the following token types:
 
 | Token Type | Format | Use Case |
 |------------|--------|----------|

--- a/src/mcp_gitlab/config.py
+++ b/src/mcp_gitlab/config.py
@@ -19,7 +19,12 @@ class GitLabConfig:
     @classmethod
     def from_env(cls) -> GitLabConfig:
         url = os.getenv("GITLAB_URL", "").rstrip("/")
-        token = os.getenv("GITLAB_TOKEN") or os.getenv("GITLAB_PAT", "")
+        token = (
+            os.getenv("GITLAB_TOKEN")
+            or os.getenv("GITLAB_PAT")
+            or os.getenv("GITLAB_PERSONAL_ACCESS_TOKEN")
+            or os.getenv("GITLAB_API_TOKEN", "")
+        )
         read_only = os.getenv("GITLAB_READ_ONLY", "false").lower() in (
             "true",
             "1",
@@ -49,5 +54,8 @@ class GitLabConfig:
             msg = "GITLAB_URL environment variable is required"
             raise ValueError(msg)
         if not self.token:
-            msg = "GITLAB_TOKEN (or GITLAB_PAT) environment variable is required"
+            msg = (
+                "GitLab token is required. Set one of: GITLAB_TOKEN, GITLAB_PAT, "
+                "GITLAB_PERSONAL_ACCESS_TOKEN, or GITLAB_API_TOKEN"
+            )
             raise ValueError(msg)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -55,6 +55,34 @@ def test_config_validate_missing_token():
         config.validate()
 
 
+def test_config_from_env_with_personal_access_token():
+    env = {"GITLAB_URL": "https://gitlab.example.com", "GITLAB_PERSONAL_ACCESS_TOKEN": "glpat-pat"}
+    with patch.dict(os.environ, env, clear=False):
+        config = GitLabConfig.from_env()
+    assert config.token == "glpat-pat"
+
+
+def test_config_from_env_with_api_token():
+    env = {"GITLAB_URL": "https://gitlab.example.com", "GITLAB_API_TOKEN": "glpat-api"}
+    with patch.dict(os.environ, env, clear=False):
+        config = GitLabConfig.from_env()
+    assert config.token == "glpat-api"
+
+
+def test_config_token_priority():
+    """GITLAB_TOKEN takes precedence over all other aliases."""
+    env = {
+        "GITLAB_URL": "https://gitlab.example.com",
+        "GITLAB_TOKEN": "winner",
+        "GITLAB_PAT": "loser1",
+        "GITLAB_PERSONAL_ACCESS_TOKEN": "loser2",
+        "GITLAB_API_TOKEN": "loser3",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        config = GitLabConfig.from_env()
+    assert config.token == "winner"
+
+
 def test_config_url_strips_trailing_slash():
     env = {"GITLAB_URL": "https://gitlab.example.com/", "GITLAB_TOKEN": "x"}
     with patch.dict(os.environ, env, clear=False):


### PR DESCRIPTION
## Summary
- Add `GITLAB_PERSONAL_ACCESS_TOKEN` and `GITLAB_API_TOKEN` as fallback env vars
- Resolution order: `GITLAB_TOKEN` > `GITLAB_PAT` > `GITLAB_PERSONAL_ACCESS_TOKEN` > `GITLAB_API_TOKEN`
- README updated with full alias list
- 3 new tests (two aliases + priority)

Closes #25