### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## Summary
- Adds Dependabot for `pip` ecosystem (Python dependencies from pyproject.toml)
- Adds Dependabot for `github-actions` ecosystem (CI workflow actions)
- Weekly schedule (Mondays), prefixed commit messages

## Test plan
- [ ] Verify Dependabot opens PRs on next scheduled run