### PR TITLE
fix: harden resource/prompt loading and add URL support

### DIFF
--- a/src/mcp_gitlab/resources/prompts/diagnose-pipeline.md
+++ b/src/mcp_gitlab/resources/prompts/diagnose-pipeline.md
@@ -1,8 +1,8 @@
-# Diagnose pipeline {pipeline_id} in project {project_id}
+# Diagnose pipeline $pipeline_id in project $project_id
 
 ## Steps
 
-1. **Fetch pipeline details** — use `gitlab_get_pipeline` with project_id="{project_id}" and pipeline_id="{pipeline_id}". Note the status, ref, and created timestamp.
+1. **Fetch pipeline details** — use `gitlab_get_pipeline` with project_id="$project_id" and pipeline_id="$pipeline_id". Note the status, ref, and created timestamp.
 2. **Identify failed jobs** — from the pipeline response, find jobs with status "failed". List each failed job with its name, stage, and runner.
 3. **Get job logs** — for each failed job, use `gitlab_get_job_log` to retrieve the trace output. Focus on the last 100 lines where errors typically appear.
 4. **Analyze errors** — for each failed job log, identify:

--- a/src/mcp_gitlab/resources/prompts/prepare-release.md
+++ b/src/mcp_gitlab/resources/prompts/prepare-release.md
@@ -1,15 +1,15 @@
-# Prepare release {tag_name} from {ref} in project {project_id}
+# Prepare release $tag_name from $ref in project $project_id
 
 ## Steps
 
-1. **List existing tags** — use `gitlab_list_tags` with project_id="{project_id}" to find the most recent tag. This is the baseline for the changelog.
-2. **Compare commits** — use `gitlab_compare` with project_id="{project_id}", from the previous tag to "{ref}". This gives all commits that will be in this release.
+1. **List existing tags** — use `gitlab_list_tags` with project_id="$project_id" to find the most recent tag. This is the baseline for the changelog.
+2. **Compare commits** — use `gitlab_compare` with project_id="$project_id", from the previous tag to "$ref". This gives all commits that will be in this release.
 3. **Build changelog** — from the commit list, group by conventional commit type:
    - **Features** (`feat:`): new functionality
    - **Fixes** (`fix:`): bug corrections
    - **Breaking Changes** (`BREAKING CHANGE:` or `!:`): API/behavior changes
    - **Other**: refactor, docs, chore, ci, test, perf
 4. **Draft release notes** — format as markdown with sections for each group. Include commit hash references and author attribution.
-5. **Create tag** — use `gitlab_create_tag` with project_id="{project_id}", tag_name="{tag_name}", ref="{ref}", and the release notes as the message.
-6. **Create release** — use `gitlab_create_release` with project_id="{project_id}", tag_name="{tag_name}", and the formatted changelog as the description.
+5. **Create tag** — use `gitlab_create_tag` with project_id="$project_id", tag_name="$tag_name", ref="$ref", and the release notes as the message.
+6. **Create release** — use `gitlab_create_release` with project_id="$project_id", tag_name="$tag_name", and the formatted changelog as the description.
 7. **Verify** — confirm the tag and release were created. Report any issues.

--- a/src/mcp_gitlab/resources/prompts/review-mr.md
+++ b/src/mcp_gitlab/resources/prompts/review-mr.md
@@ -1,8 +1,8 @@
-# Review MR !{mr_iid} in project {project_id}
+# Review MR !$mr_iid in project $project_id
 
 ## Steps
 
-1. **Fetch MR details** — use `gitlab_get_mr` with project_id="{project_id}" and mr_iid="{mr_iid}". Note the author, source/target branches, description, and labels.
+1. **Fetch MR details** — use `gitlab_get_mr` with project_id="$project_id" and mr_iid="$mr_iid". Note the author, source/target branches, description, and labels.
 2. **Check pipeline status** — use `gitlab_get_pipeline` with the pipeline ID from step 1. If CI has not passed, flag it before proceeding.
 3. **Get the diff** — use `gitlab_mr_changes` to retrieve all changed files.
 4. **Review each changed file** — evaluate:

--- a/src/mcp_gitlab/resources/prompts/setup-branch-protection.md
+++ b/src/mcp_gitlab/resources/prompts/setup-branch-protection.md
@@ -1,8 +1,8 @@
-# Set up branch protection for project {project_id}
+# Set up branch protection for project $project_id
 
 ## Steps
 
-1. **Review current settings** — use `gitlab_get_project` with project_id="{project_id}" to check the current merge method, approval settings, and default branch.
+1. **Review current settings** — use `gitlab_get_project` with project_id="$project_id" to check the current merge method, approval settings, and default branch.
 2. **Check existing approvals** — use `gitlab_get_project_approvals` to see current approval rules and required approval count.
 3. **Configure merge method** — use `gitlab_update_project_merge_settings` to set:
    - Merge method (merge commit, rebase, fast-forward)

--- a/src/mcp_gitlab/resources/prompts/triage-issues.md
+++ b/src/mcp_gitlab/resources/prompts/triage-issues.md
@@ -1,11 +1,11 @@
-# Triage issues in project {project_id}
+# Triage issues in project $project_id
 
 ## Parameters
-- **Label filter**: {label}
+- **Label filter**: $label
 
 ## Steps
 
-1. **List open issues** — use `gitlab_list_issues` with project_id="{project_id}", state="opened", and labels="{label}" (if provided). Retrieve up to 100 issues.
+1. **List open issues** — use `gitlab_list_issues` with project_id="$project_id", state="opened", and labels="$label" (if provided). Retrieve up to 100 issues.
 2. **Categorize** — group issues by:
    - **Bug reports**: issues with "bug" label or bug-related keywords
    - **Feature requests**: issues with "feature" or "enhancement" labels

--- a/src/mcp_gitlab/servers/_helpers.py
+++ b/src/mcp_gitlab/servers/_helpers.py
@@ -1,0 +1,72 @@
+"""Shared helper functions for server modules."""
+
+from __future__ import annotations
+
+import functools
+import re
+from pathlib import Path
+from urllib.parse import unquote
+
+
+@functools.cache
+def _load_file(base_dir: str, filename: str) -> str:
+    """Load a file from the given directory with path traversal protection.
+
+    Results are cached — static files do not change at runtime.
+    """
+    if "/" in filename or "\\" in filename or ".." in filename:
+        msg = f"Invalid filename: {filename}"
+        raise ValueError(msg)
+    base = Path(base_dir)
+    path = base / filename
+    if not path.resolve().is_relative_to(base.resolve()):
+        msg = f"Invalid filename: {filename}"
+        raise ValueError(msg)
+    return path.read_text(encoding="utf-8")
+
+
+# ════════════════════════════════════════════════════════════════════
+# GitLab URL parsing
+# ════════════════════════════════════════════════════════════════════
+
+# Matches:  <host>/<namespace/project>/-/merge_requests/<iid>
+_MR_RE = re.compile(r"https?://[^/]+/(.+?)/-/merge_requests/(\d+)")
+# Matches:  <host>/<namespace/project>/-/pipelines/<id>
+_PIPELINE_RE = re.compile(r"https?://[^/]+/(.+?)/-/pipelines/(\d+)")
+# Matches:  <host>/<namespace/project> (no /-/ suffix)
+_PROJECT_RE = re.compile(r"https?://[^/]+/(.+?)(?:/-/.*)?$")
+
+
+def _parse_gitlab_mr_url(value: str) -> tuple[str, str]:
+    """Extract (project_path, mr_iid) from a GitLab MR URL.
+
+    If *value* is not a URL, returns it unchanged as (value, "").
+    """
+    m = _MR_RE.match(value)
+    if m:
+        return unquote(m.group(1)), m.group(2)
+    return value, ""
+
+
+def _parse_gitlab_pipeline_url(value: str) -> tuple[str, str]:
+    """Extract (project_path, pipeline_id) from a GitLab pipeline URL.
+
+    If *value* is not a URL, returns it unchanged as (value, "").
+    """
+    m = _PIPELINE_RE.match(value)
+    if m:
+        return unquote(m.group(1)), m.group(2)
+    return value, ""
+
+
+def _parse_gitlab_project_url(value: str) -> str:
+    """Extract project_path from a GitLab project URL.
+
+    If *value* is not a URL, returns it unchanged.
+    """
+    if not value.startswith(("http://", "https://")):
+        return value
+    m = _PROJECT_RE.match(value)
+    if m:
+        return unquote(m.group(1))
+    return value

--- a/src/mcp_gitlab/servers/prompts.py
+++ b/src/mcp_gitlab/servers/prompts.py
@@ -3,31 +3,47 @@
 from __future__ import annotations
 
 from pathlib import Path
+from string import Template
 
 from fastmcp.prompts.prompt import Message
 
+from ._helpers import (
+    _load_file,
+    _parse_gitlab_mr_url,
+    _parse_gitlab_pipeline_url,
+    _parse_gitlab_project_url,
+)
 from .gitlab import mcp
 
-_PROMPTS_DIR = Path(__file__).resolve().parent.parent / "resources" / "prompts"
+_PROMPTS_DIR = str(Path(__file__).resolve().parent.parent / "resources" / "prompts")
 
 
 def _load_prompt(filename: str) -> str:
     """Load a prompt markdown file from the prompts directory."""
-    if "/" in filename or "\\" in filename or ".." in filename:
-        msg = f"Invalid prompt filename: {filename}"
-        raise ValueError(msg)
-    path = _PROMPTS_DIR / filename
-    if not path.resolve().is_relative_to(_PROMPTS_DIR.resolve()):
-        msg = f"Invalid prompt filename: {filename}"
-        raise ValueError(msg)
-    return path.read_text(encoding="utf-8")
+    return _load_file(_PROMPTS_DIR, filename)
+
+
+def _render(filename: str, **kwargs: str) -> str:
+    """Load a prompt template and substitute variables safely.
+
+    Uses string.Template ($var) instead of str.format({var}) to avoid
+    KeyError when parameter values contain curly braces.
+    """
+    return Template(_load_prompt(filename)).safe_substitute(kwargs)
 
 
 @mcp.prompt(tags={"gitlab", "review"})
-def review_mr(project_id: str, mr_iid: str) -> list[Message]:
+def review_mr(project_id: str, mr_iid: str = "") -> list[Message]:
     """Review a GitLab merge request — fetch details, check pipeline, review
-    changes, and write discussion comments."""
-    text = _load_prompt("review-mr.md").format(project_id=project_id, mr_iid=mr_iid)
+    changes, and write discussion comments.
+
+    Accepts a full MR URL (e.g. https://gitlab.com/group/project/-/merge_requests/42)
+    as project_id — mr_iid will be extracted automatically.
+    """
+    parsed_project, parsed_iid = _parse_gitlab_mr_url(project_id)
+    if parsed_iid:
+        project_id, mr_iid = parsed_project, parsed_iid
+    text = _render("review-mr.md", project_id=project_id, mr_iid=mr_iid)
     return [
         Message(role="user", content=text),
         Message(
@@ -41,12 +57,17 @@ def review_mr(project_id: str, mr_iid: str) -> list[Message]:
 
 
 @mcp.prompt(tags={"gitlab", "ci"})
-def diagnose_pipeline(project_id: str, pipeline_id: str) -> list[Message]:
+def diagnose_pipeline(project_id: str, pipeline_id: str = "") -> list[Message]:
     """Diagnose a failed CI/CD pipeline — identify failed jobs, get logs,
-    analyze errors, and suggest fixes."""
-    text = _load_prompt("diagnose-pipeline.md").format(
-        project_id=project_id, pipeline_id=pipeline_id
-    )
+    analyze errors, and suggest fixes.
+
+    Accepts a full pipeline URL (e.g. https://gitlab.com/group/project/-/pipelines/999)
+    as project_id — pipeline_id will be extracted automatically.
+    """
+    parsed_project, parsed_pid = _parse_gitlab_pipeline_url(project_id)
+    if parsed_pid:
+        project_id, pipeline_id = parsed_project, parsed_pid
+    text = _render("diagnose-pipeline.md", project_id=project_id, pipeline_id=pipeline_id)
     return [
         Message(role="user", content=text),
         Message(
@@ -62,10 +83,12 @@ def diagnose_pipeline(project_id: str, pipeline_id: str) -> list[Message]:
 @mcp.prompt(tags={"gitlab", "release"})
 def prepare_release(project_id: str, tag_name: str, ref: str = "main") -> list[Message]:
     """Prepare a release — compare commits since last tag, draft changelog,
-    create tag and release."""
-    text = _load_prompt("prepare-release.md").format(
-        project_id=project_id, tag_name=tag_name, ref=ref
-    )
+    create tag and release.
+
+    project_id accepts a full GitLab project URL.
+    """
+    project_id = _parse_gitlab_project_url(project_id)
+    text = _render("prepare-release.md", project_id=project_id, tag_name=tag_name, ref=ref)
     return [
         Message(role="user", content=text),
         Message(
@@ -81,8 +104,12 @@ def prepare_release(project_id: str, tag_name: str, ref: str = "main") -> list[M
 @mcp.prompt(tags={"gitlab", "settings"})
 def setup_branch_protection(project_id: str) -> list[Message]:
     """Set up branch protection — review settings, configure merge method,
-    and create approval rules."""
-    text = _load_prompt("setup-branch-protection.md").format(project_id=project_id)
+    and create approval rules.
+
+    project_id accepts a full GitLab project URL.
+    """
+    project_id = _parse_gitlab_project_url(project_id)
+    text = _render("setup-branch-protection.md", project_id=project_id)
     return [
         Message(role="user", content=text),
         Message(
@@ -98,8 +125,12 @@ def setup_branch_protection(project_id: str) -> list[Message]:
 @mcp.prompt(tags={"gitlab", "issues"})
 def triage_issues(project_id: str, label: str = "") -> list[Message]:
     """Triage open issues — categorize, prioritize, identify duplicates,
-    and suggest labels."""
-    text = _load_prompt("triage-issues.md").format(project_id=project_id, label=label)
+    and suggest labels.
+
+    project_id accepts a full GitLab project URL.
+    """
+    project_id = _parse_gitlab_project_url(project_id)
+    text = _render("triage-issues.md", project_id=project_id, label=label)
     return [
         Message(role="user", content=text),
         Message(
@@ -111,3 +142,28 @@ def triage_issues(project_id: str, label: str = "") -> list[Message]:
             ),
         ),
     ]
+
+
+# ════════════════════════════════════════════════════════════════════
+# Startup validation
+# ════════════════════════════════════════════════════════════════════
+
+_PROMPT_FILES = [
+    "review-mr.md",
+    "diagnose-pipeline.md",
+    "prepare-release.md",
+    "setup-branch-protection.md",
+    "triage-issues.md",
+]
+
+
+def _validate_prompts() -> None:
+    """Verify all expected prompt files exist at import time."""
+    _dir = Path(_PROMPTS_DIR)
+    missing = [f for f in _PROMPT_FILES if not (_dir / f).is_file()]
+    if missing:
+        msg = f"Missing prompt files (packaging error): {missing}"
+        raise RuntimeError(msg)
+
+
+_validate_prompts()

--- a/src/mcp_gitlab/servers/resources.py
+++ b/src/mcp_gitlab/servers/resources.py
@@ -4,21 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ._helpers import _load_file
 from .gitlab import mcp
 
-_RESOURCES_DIR = Path(__file__).resolve().parent.parent / "resources"
+_RESOURCES_DIR = str(Path(__file__).resolve().parent.parent / "resources")
 
 
 def _load(filename: str) -> str:
     """Load a resource markdown file from the resources directory."""
-    if "/" in filename or "\\" in filename or ".." in filename:
-        msg = f"Invalid resource filename: {filename}"
-        raise ValueError(msg)
-    path = _RESOURCES_DIR / filename
-    if not path.resolve().is_relative_to(_RESOURCES_DIR.resolve()):
-        msg = f"Invalid resource filename: {filename}"
-        raise ValueError(msg)
-    return path.read_text(encoding="utf-8")
+    return _load_file(_RESOURCES_DIR, filename)
 
 
 # ════════════════════════════════════════════════════════════════════
@@ -119,3 +113,29 @@ def code_review_guide() -> str:
 def codeowners_guide() -> str:
     """GitLab CODEOWNERS file reference and governance."""
     return _load("codeowners.md")
+
+
+# ════════════════════════════════════════════════════════════════════
+# Startup validation
+# ════════════════════════════════════════════════════════════════════
+
+_RESOURCE_FILES = [
+    "gitlab-ci.md",
+    "git-workflow.md",
+    "mr-hygiene.md",
+    "conventional-commits.md",
+    "code-review.md",
+    "codeowners.md",
+]
+
+
+def _validate_resources() -> None:
+    """Verify all expected resource files exist at import time."""
+    _dir = Path(_RESOURCES_DIR)
+    missing = [f for f in _RESOURCE_FILES if not (_dir / f).is_file()]
+    if missing:
+        msg = f"Missing resource files (packaging error): {missing}"
+        raise RuntimeError(msg)
+
+
+_validate_resources()

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from mcp_gitlab.servers.resources import (
     _RESOURCES_DIR,
     _load,
@@ -60,11 +62,11 @@ class TestResourceFiles:
     """Verify resource .md files exist and are valid."""
 
     def test_resources_dir_exists(self) -> None:
-        assert _RESOURCES_DIR.is_dir(), f"Resources directory missing: {_RESOURCES_DIR}"
+        assert Path(_RESOURCES_DIR).is_dir(), f"Resources directory missing: {_RESOURCES_DIR}"
 
     def test_all_files_exist(self) -> None:
         for filename in RESOURCE_FILES:
-            path = _RESOURCES_DIR / filename
+            path = Path(_RESOURCES_DIR) / filename
             assert path.is_file(), f"Missing resource file: {path}"
 
     def test_load_returns_content(self) -> None:
@@ -92,25 +94,25 @@ class TestLoadSecurity:
     def test_rejects_directory_traversal(self) -> None:
         import pytest
 
-        with pytest.raises(ValueError, match="Invalid resource filename"):
+        with pytest.raises(ValueError, match="Invalid filename"):
             _load("../../../etc/passwd")
 
     def test_rejects_forward_slash(self) -> None:
         import pytest
 
-        with pytest.raises(ValueError, match="Invalid resource filename"):
+        with pytest.raises(ValueError, match="Invalid filename"):
             _load("subdir/file.md")
 
     def test_rejects_backslash(self) -> None:
         import pytest
 
-        with pytest.raises(ValueError, match="Invalid resource filename"):
+        with pytest.raises(ValueError, match="Invalid filename"):
             _load("subdir\\file.md")
 
     def test_rejects_dotdot_only(self) -> None:
         import pytest
 
-        with pytest.raises(ValueError, match="Invalid resource filename"):
+        with pytest.raises(ValueError, match="Invalid filename"):
             _load("..")
 
 


### PR DESCRIPTION
## Summary

- Create `servers/_helpers.py` with shared `_load_file()` + `@functools.cache` — eliminates duplicated path-traversal logic
- Replace `str.format()` with `string.Template.safe_substitute()` in all 5 prompts — prevents `KeyError` on curly braces in values
- Convert 5 prompt `.md` templates from `{var}` to `$var` syntax
- Add `_validate_resources()` (6 files) / `_validate_prompts()` (5 files) startup checks
- Add GitLab URL parsers (`_parse_gitlab_mr_url`, `_parse_gitlab_pipeline_url`, `_parse_gitlab_project_url`) so prompts accept full GitLab URLs — plain IDs still work

## Test plan

- [x] 187 tests pass (`uv run python -m pytest tests/ -v`)
- [x] `ruff check` + `ruff format --check` clean
- [x] New tests: `TestURLParsing` (6 cases), curly-brace safety test, `Path()` wrapping fixes for type change