### PR TITLE
fix: shorten server.json description for MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vish288/mcp-gitlab",
-  "description": "MCP server for GitLab API — 76 tools for AI assistants. Projects, MRs, pipelines, CI/CD, approvals, issues, code review.",
+  "description": "MCP server for GitLab API — projects, MRs, pipelines, CI/CD, approvals, issues, code review.",
   "repository": {
     "url": "https://github.com/vish288/mcp-gitlab",
     "source": "github"


### PR DESCRIPTION
Registry requires description <= 100 chars. Trimmed from 120 to 92.