### PR TITLE
docs: fix doc drifts and extend release workflow to bump server.json/gemini-extension.json

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,18 +38,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update server.json version
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          python3 -c "
-          import json
-          with open('server.json') as f: d = json.load(f)
-          d['version'] = '$VERSION'
-          for p in d.get('packages', []):
-              p['version'] = '$VERSION'
-          with open('server.json', 'w') as f: json.dump(d, f, indent=2); f.write('\n')
-          "
-
       - name: Install mcp-publisher
         run: |
           curl -sL https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz | tar xz -C /usr/local/bin mcp-publisher

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,33 @@ jobs:
             [ -f "$f" ] && sed -i 's/^- \*\*Version\*\*: .*/- **Version**: ${{ steps.next.outputs.version }}/' "$f"
           done
 
+      - name: Update server.json and gemini-extension.json versions
+        env:
+          NEXT_VERSION: ${{ steps.next.outputs.version }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          version = os.environ["NEXT_VERSION"]
+
+          with open("server.json") as f:
+              data = json.load(f)
+          data["version"] = version
+          for pkg in data.get("packages", []):
+              pkg["version"] = version
+          with open("server.json", "w") as f:
+              json.dump(data, f, indent=2)
+              f.write("\n")
+
+          with open("gemini-extension.json") as f:
+              data = json.load(f)
+          data["version"] = version
+          with open("gemini-extension.json", "w") as f:
+              json.dump(data, f, indent=2)
+              f.write("\n")
+          PY
+
       - name: Regenerate uv.lock
         run: uv lock
 
@@ -165,6 +192,8 @@ jobs:
           CHANGELOG_BLOB=$(create_blob CHANGELOG.md)
           LLMS_BLOB=$(create_blob llms.txt)
           LLMS_FULL_BLOB=$(create_blob llms-full.txt)
+          SERVER_BLOB=$(create_blob server.json)
+          GEMINI_BLOB=$(create_blob gemini-extension.json)
 
           # Create tree with all release files
           NEW_TREE=$(gh api repos/${{ github.repository }}/git/trees \
@@ -202,6 +231,18 @@ jobs:
                 "mode": "100644",
                 "type": "blob",
                 "sha": "$LLMS_FULL_BLOB"
+              },
+              {
+                "path": "server.json",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "$SERVER_BLOB"
+              },
+              {
+                "path": "gemini-extension.json",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "$GEMINI_BLOB"
               }
             ]
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Every tool MUST have `annotations={}` with at minimum `readOnlyHint`.
 
 ## Tool Categories
 
-Projects (4), Approvals (10), Groups (6), Branches (3), Commits (4), Merge Requests (16), MR Notes (6), MR Discussions (4), Pipelines (5), Jobs (4), Tags (4), Releases (5), CI/CD Variables (8), Issues (5)
+Projects (4), Approvals (10), Groups (6), Branches (3), Commits (4), Merge Requests (15), MR Notes (6), MR Discussions (4), Pipelines (5), Jobs (4), Tags (4), Releases (5), CI/CD Variables (8), Issues (5)
 
 ## Environment Variables
 
@@ -86,8 +86,8 @@ gh workflow run release.yml -f bump=minor -f dry_run=true
 
 ### What happens
 
-1. `release.yml` (workflow_dispatch) — bumps `pyproject.toml` version, regenerates `uv.lock`, generates CHANGELOG.md, creates release commit + tag via GitHub API
-2. `publish.yml` (triggered by `v*` tag push) — builds wheel, publishes to PyPI, creates GitHub Release with auto-generated notes
+1. `release.yml` (workflow_dispatch) — bumps the version in `pyproject.toml`, `llms.txt`, `llms-full.txt`, `server.json`, `gemini-extension.json`; regenerates `uv.lock`; prepends a CHANGELOG.md entry; creates the release commit + tag via the GitHub API
+2. `publish.yml` (triggered by `v*` tag push) — builds wheel, publishes to PyPI, creates GitHub Release with auto-generated notes, then publishes to the MCP Registry
 
 ### Rules
 - Never edit `pyproject.toml` version directly — the workflow owns it

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ These accept any of the following token types:
 | Windsurf | Yes | `~/.codeium/windsurf/mcp_config.json` |
 | Any MCP client | Yes | stdio or HTTP transport |
 
-## Tools (84)
+## Tools (83)
 
 | Category | Count | Tools |
 |----------|-------|-------|

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-gitlab",
-  "version": "0.6.8",
+  "version": "0.9.0",
   "description": "MCP server for GitLab API — projects, MRs, pipelines, CI/CD variables, approvals, and more",
   "mcpServers": {
     "mcp-gitlab": {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15,7 +15,7 @@ MCP server that wraps the GitLab REST API. Works with GitLab.com and self-hosted
 
 ## Documentation
 
-- [README](https://github.com/vish288/mcp-gitlab#readme): canonical reference for setup, env vars, all 83 tools, 6 resources, 5 prompts
+- [README](https://github.com/vish288/mcp-gitlab#readme): canonical reference for setup, env vars, all 83 tools, 7 resources, 6 prompts
 - [PyPI](https://pypi.org/project/mcp-gitlab/): install via `pip install mcp-gitlab` or `uvx mcp-gitlab`
 - [GitHub](https://github.com/vish288/mcp-gitlab): source code, issue tracker, development setup
 - [MCP Registry](https://registry.modelcontextprotocol.io): discover and install MCP servers
@@ -79,7 +79,7 @@ uvx mcp-gitlab --gitlab-url https://gitlab.example.com --gitlab-token glpat-xxx 
 | Delete projects, manage approval rules | Maintainer/Owner |
 | Share projects/groups | Owner (or Admin) |
 
-## Tools (84)
+## Tools (83)
 
 ### Projects (4)
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,7 +15,7 @@ MCP server that wraps the GitLab REST API. Works with GitLab.com and self-hosted
 
 ## Documentation
 
-- [README](https://github.com/vish288/mcp-gitlab#readme): canonical reference for setup, env vars, all 83 tools, 6 resources, 5 prompts
+- [README](https://github.com/vish288/mcp-gitlab#readme): canonical reference for setup, env vars, all 83 tools, 7 resources, 6 prompts
 - [PyPI](https://pypi.org/project/mcp-gitlab/): install via `pip install mcp-gitlab` or `uvx mcp-gitlab`
 - [GitHub](https://github.com/vish288/mcp-gitlab): source code, issue tracker, development setup
 - [MCP Registry](https://registry.modelcontextprotocol.io): discover and install MCP servers

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/vish288/mcp-gitlab",
     "source": "github"
   },
-  "version": "0.6.8",
+  "version": "0.9.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-gitlab",
-      "version": "0.6.8",
+      "version": "0.9.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Two layers of fix:

### 1. Doc drifts (current snapshot)
| File | Before | After |
|---|---|---|
| `README.md:114` | `## Tools (84)` | `## Tools (83)` |
| `llms-full.txt:82` | `## Tools (84)` | `## Tools (83)` |
| `llms.txt:18`, `llms-full.txt:18` | `6 resources, 5 prompts` | `7 resources, 6 prompts` |
| `AGENTS.md:61` | `Merge Requests (16)` | `Merge Requests (15)` |
| `server.json` | `0.6.8` (both fields) | `0.9.0` |
| `gemini-extension.json` | `0.6.8` | `0.9.0` |

`server.json` and `gemini-extension.json` were pinned to 0.6.8 because nothing in the repo ever wrote a corrected version back: `publish.yml` rewrote `server.json` in-runner immediately before calling `mcp-publisher` but never committed; `gemini-extension.json` was untouched by any workflow.

### 2. Workflow gap (prevents future drift)
- `release.yml` now bumps `server.json` and `gemini-extension.json` alongside `pyproject.toml`, `llms.txt`, `llms-full.txt` and includes both in the release commit via the GitHub API.
- `publish.yml`: removed the now-redundant in-runner `server.json` rewrite — the release commit carries the correct version, so the publish-time mutation is no-op.
- `AGENTS.md` "What happens" section now lists the full set of bumped files and mentions the MCP Registry publish step for accuracy.

No functional code changes.

## Test plan
- [x] `uv run pytest -q` — 252 passed
- [x] `uv run ruff check src tests` — clean
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — valid
- [x] `python -c "import json; json.load(open('server.json')); json.load(open('gemini-extension.json'))"` — valid
- [ ] Next release run: confirm the release commit contains the new versions in `server.json` and `gemini-extension.json`